### PR TITLE
Fix error when uploading file without providing -p.

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -276,16 +276,16 @@ var cmd = function () {
         'pin': ['sendMessage', function (callback, pipe) {
             logger.debug('pin message');
 
-	    if (options.file) {
-		return callback('pinning a file is not supported');
-	    }
-
 	    if (!options.message) {
 		return callback();
 	    }
 
 	    if (!options.pin) {
 		return callback();
+	    }
+
+            if (options.file) {
+		return callback('pinning a file is not supported');
 	    }
 
             var channelId = pipe.sendMessage.channel;


### PR DESCRIPTION
Don't send an error when we are uploading a file without providing the p flag

Fix #14 
