### PR TITLE
Fix use of deprecated methods

### DIFF
--- a/bin/cmd.js
+++ b/bin/cmd.js
@@ -175,7 +175,7 @@ var cmd = function () {
                 return callback();
             }
 
-            post(api('groups.list'), {}, function (err, response, body) {
+            post(api('conversations.list'), {}, function (err, response, body) {
                 if (err) {
                     return callback(err);
                 }
@@ -216,7 +216,7 @@ var cmd = function () {
                 return callback();
             }
 
-            post(api('channels.list'), {}, function (err, response, body) {
+            post(api('conversations.list'), {}, function (err, response, body) {
                 if (err) {
                     return callback(err);
                 }


### PR DESCRIPTION
The methods `groups.list` and `channels.list` have been deprecated in favor of `conversations.list`

https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api